### PR TITLE
Update pulsar to latest via commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-gtfsrt-full-publisher</artifactId>
-    <version>0.2.0</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.4.0</common.version>
+        <common.version>1.0.0</common.version>
     </properties>
 
     <repositories>
@@ -30,7 +29,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>5.0.0</version>
+            <version>8.0.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
also update on azure-storage so that jackson library version won't clash

Requires merging of [HSLdevcom/transitdata-common#57](https://github.com/HSLdevcom/transitdata-common/pull/57)
