### PR TITLE
Feat/dont publish old updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Application for building GTFS-RT Full dataset from Pulsar TripUpdate or ServiceA
 Final bundle will be uploaded to remote file server. Currently supported is Azure Blob Storage. 
 There is an option also to save the file locally for easier debugging.
 
+Currently application has separate logic for publishing ServiceAlerts and TripUpdates. 
+- With ServiceAlerts we can just publish the latest FeedMessage since it contains the whole state
+- With TripUpdates we need to cache all incoming FeedMessages which contain information about a single trip.
+  - When publishing we aggregate FeedEntities from each FeedMessage and publish them under one FeedMessage 
+  - We also want to filter past events from the output feed (and the cache). 
+    - Currently we do this by filtering the entire FeedEntity once all events are old. We could also filter single TripUpdates once they deprecate?
+
+
 ## Building
 
 ### Dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.7.2</common.version>
+        <common.version>0.7.3</common.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-gtfsrt-full-publisher</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -10,7 +10,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.4.0</common.version>
+        <common.version>0.7.2</common.version>
     </properties>
 
     <repositories>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>5.0.0</version>
+            <version>8.0.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/fi/hsl/transitdata/publisher/AzureSink.java
+++ b/src/main/java/fi/hsl/transitdata/publisher/AzureSink.java
@@ -31,7 +31,7 @@ public class AzureSink implements ISink {
     public static AzureSink newInstance(Config config) throws Exception {
         String name = config.getString("bundler.output.azure.accountName");
         String container = config.getString("bundler.output.azure.containerName");
-        long maxAge = config.getDuration("bundler.cacheMaxAge", TimeUnit.SECONDS);
+        long maxAge = config.getDuration("bundler.output.azure.cacheMaxAge", TimeUnit.SECONDS);
 
         //We'll use Docker secrets for getting the key
         String keyPath = config.getString("bundler.output.azure.accountKeyPath");

--- a/src/main/java/fi/hsl/transitdata/publisher/DatasetEntry.java
+++ b/src/main/java/fi/hsl/transitdata/publisher/DatasetEntry.java
@@ -6,10 +6,10 @@ import org.apache.pulsar.client.api.Message;
 import java.util.List;
 
 public class DatasetEntry {
-    private DatasetEntry(long id, long evetTimeMs, GtfsRealtime.FeedMessage feedMessage) {
+    private DatasetEntry(long id, long eventTimeMs, GtfsRealtime.FeedMessage feedMessage) {
         this.dvjId = id;
         this.feedMessage = feedMessage;
-        this.eventTimeMs = evetTimeMs;
+        this.eventTimeMs = eventTimeMs;
     }
 
     private long dvjId;

--- a/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
+++ b/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
@@ -69,19 +69,6 @@ public class TripUpdatePublisher extends DatasetPublisher {
         //merge with previous entries. Only keep latest.
         newMessages.forEach(entry -> cache.put(entry.getDvjId(), entry));
     }
-    /*
-    static void removeOldEntries(Map<Long, DatasetEntry> cache, long maxAgeInSecs, long nowUtcMs) {
-        Iterator<Map.Entry<Long, DatasetEntry>> it = cache.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<Long, DatasetEntry> pair = it.next();
-
-            long ts = pair.getValue().getEventTimeUtcMs();
-            long age = nowUtcMs - ts;
-            if (age > maxAgeInSecs) {
-                it.remove();
-            }
-        }
-    }*/
 
     static void removeOldEntries(Map<Long, DatasetEntry> cache, long keepAfterLastEventInSecs, long nowInSecs) {
         Iterator<Map.Entry<Long, DatasetEntry>> it = cache.entrySet().iterator();

--- a/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
+++ b/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
@@ -2,7 +2,7 @@ package fi.hsl.transitdata.publisher;
 
 import com.google.transit.realtime.GtfsRealtime;
 import com.typesafe.config.Config;
-import fi.hsl.common.gtfsrt.GtfsRtUtils;
+import fi.hsl.common.gtfsrt.FeedMessageFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class TripUpdatePublisher extends DatasetPublisher {
         }
 
         final long nowInSecs = now / 1000;
-        GtfsRealtime.FeedMessage fullDump = GtfsRtUtils.createFullFeedMessage(entities, nowInSecs);
+        GtfsRealtime.FeedMessage fullDump = FeedMessageFactory.createFullFeedMessage(entities, nowInSecs);
 
         sink.put(fileName, fullDump.toByteArray());
 

--- a/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
+++ b/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
@@ -2,6 +2,7 @@ package fi.hsl.transitdata.publisher;
 
 import com.google.transit.realtime.GtfsRealtime;
 import com.typesafe.config.Config;
+import fi.hsl.common.gtfsrt.GtfsRtUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class TripUpdatePublisher extends DatasetPublisher {
         }
 
         final long nowInSecs = now / 1000;
-        GtfsRealtime.FeedMessage fullDump = createFeedMessage(entities, nowInSecs);
+        GtfsRealtime.FeedMessage fullDump = GtfsRtUtils.createFullFeedMessage(entities, nowInSecs);
 
         sink.put(fileName, fullDump.toByteArray());
 
@@ -91,17 +92,5 @@ public class TripUpdatePublisher extends DatasetPublisher {
                 .collect(Collectors.toList());
     }
 
-    static GtfsRealtime.FeedMessage createFeedMessage(List<GtfsRealtime.FeedEntity> entities, long timestampUtcSecs) {
-        GtfsRealtime.FeedHeader header = GtfsRealtime.FeedHeader.newBuilder()
-                .setGtfsRealtimeVersion("2.0")
-                .setIncrementality(GtfsRealtime.FeedHeader.Incrementality.FULL_DATASET)
-                .setTimestamp(timestampUtcSecs)
-                .build();
-
-        return GtfsRealtime.FeedMessage.newBuilder()
-                .addAllEntity(entities)
-                .setHeader(header)
-                .build();
-    }
 
 }

--- a/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
+++ b/src/main/java/fi/hsl/transitdata/publisher/TripUpdatePublisher.java
@@ -14,12 +14,12 @@ public class TripUpdatePublisher extends DatasetPublisher {
     private static final Logger log = LoggerFactory.getLogger(TripUpdatePublisher.class);
 
     final HashMap<Long, DatasetEntry> cache = new HashMap<>();
-    final long maxAgeInMs;
+    final long maxAgeInSecs;
 
 
     protected TripUpdatePublisher(Config config, ISink sink) {
         super(config, sink);
-        maxAgeInMs = config.getDuration("bundler.tripUpdate.maxAge", TimeUnit.MILLISECONDS);
+        maxAgeInSecs = config.getDuration("bundler.tripUpdate.contentMaxAge", TimeUnit.SECONDS);
     }
 
     public void initialize() throws Exception {
@@ -39,11 +39,11 @@ public class TripUpdatePublisher extends DatasetPublisher {
         log.info("Cache size after merging: {}", cache.size());
 
         //filter old ones out
-        log.info("Pruning cache, removing events older than {}", maxAgeInMs);
+        log.info("Pruning cache, removing events older than {} secs", maxAgeInSecs);
         int sizeBefore = cache.size();
 
-        final long now = System.currentTimeMillis();
-        removeOldEntries(cache, maxAgeInMs, now);
+        final long nowInSecs = System.currentTimeMillis() / 1000;
+        removeOldEntries(cache, maxAgeInSecs, nowInSecs);
         int sizeAfter = cache.size();
         log.info("Size before pruning {} and after {}", sizeBefore, sizeAfter);
 
@@ -55,7 +55,6 @@ public class TripUpdatePublisher extends DatasetPublisher {
             log.error("Cache size != entity-list size. Bug or is something strange happening here..?");
         }
 
-        final long nowInSecs = now / 1000;
         GtfsRealtime.FeedMessage fullDump = FeedMessageFactory.createFullFeedMessage(entities, nowInSecs);
 
         sink.put(fileName, fullDump.toByteArray());
@@ -71,36 +70,46 @@ public class TripUpdatePublisher extends DatasetPublisher {
         newMessages.forEach(entry -> cache.put(entry.getDvjId(), entry));
     }
     /*
-    static void removeOldEntries(Map<Long, DatasetEntry> cache, long maxAgeInMs, long nowUtcMs) {
+    static void removeOldEntries(Map<Long, DatasetEntry> cache, long maxAgeInSecs, long nowUtcMs) {
         Iterator<Map.Entry<Long, DatasetEntry>> it = cache.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<Long, DatasetEntry> pair = it.next();
 
             long ts = pair.getValue().getEventTimeUtcMs();
             long age = nowUtcMs - ts;
-            if (age > maxAgeInMs) {
+            if (age > maxAgeInSecs) {
                 it.remove();
             }
         }
     }*/
 
-    static void removeOldEntries(Map<Long, DatasetEntry> cache, long keepAfterLastEventInMs, long nowUtcMs) {
-        final long maxAgeInMs = nowUtcMs + keepAfterLastEventInMs;
-
+    static void removeOldEntries(Map<Long, DatasetEntry> cache, long keepAfterLastEventInSecs, long nowInSecs) {
         Iterator<Map.Entry<Long, DatasetEntry>> it = cache.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<Long, DatasetEntry> pair = it.next();
+            // Note! By filtering out the whole FeedMessage we assume that it only contains
+            // FeedEntities for a single trip. Currently this is so, but needs to be fixed if things change.
+            // Let's add a warning which should be monitored
+            GtfsRealtime.FeedMessage feedMessage = pair.getValue().getFeedMessage();
+            if (feedMessage.getEntityCount() != 1) {
+                log.error("FeedMessage entity count != 1. count: {}", feedMessage.getEntityCount());
+                for (GtfsRealtime.FeedEntity entity: feedMessage.getEntityList()) {
+                    log.debug("FeedEntity Id: {}", entity.getId());
+                }
+            }
 
-            long ts = pair.getValue().getEventTimeUtcMs();
-            long age = nowUtcMs - ts;
-            if (age > maxAgeInMs) {
+            long latestTimestampInFeedMessage = findLatestTimestamp(feedMessage);
+            long age = nowInSecs - latestTimestampInFeedMessage;
+            if (age > keepAfterLastEventInSecs) {
+                log.debug("Removing because age is {} s", age);
                 it.remove();
             }
         }
     }
 
     protected static Long findLatestTimestamp(GtfsRealtime.FeedMessage msg) {
-        Optional<Long> maxTimestamp = msg.getEntityList().stream().map(GtfsRealtime.FeedEntity::getTripUpdate)
+        Optional<Long> maxTimestamp = msg.getEntityList().stream()
+                .map(GtfsRealtime.FeedEntity::getTripUpdate)
                 .map(tu -> {
                     return tu.getStopTimeUpdateList().stream().map(
                             stu -> {
@@ -116,11 +125,11 @@ public class TripUpdatePublisher extends DatasetPublisher {
                                 }
                                 return max;
                             }
-                    ).max(Comparator.naturalOrder());
+                    ).max(Comparator.naturalOrder()); // Get latest timestamp of all StopTimeUpdates in this TripUpdate
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .max(Comparator.naturalOrder());
+                .max(Comparator.naturalOrder()); // Get latest timestamp of all TripUpdates in this FeedEntityList
          return maxTimestamp.orElse(0L);
     }
 

--- a/src/main/resources/environment.conf
+++ b/src/main/resources/environment.conf
@@ -20,8 +20,6 @@ bundler {
   dumpInterval = ${?DUMP_INTERVAL}
   dataType = "TripUpdate" # TripUpdate or ServiceAlert
   dataType = ${?DATA_TYPE}
-  cacheMaxAge = 5 seconds
-  cacheMaxAge = ${?CACHE_MAX_AGE}
   tripUpdate {
     maxAge = 3 hours
     maxAge = ${?TRIP_UPDATE_MAX_AGE}
@@ -42,6 +40,8 @@ bundler {
       accountKeyPath = ${?AZURE_ACCOUNT_KEY_PATH}
       containerName= "transitdata-public-container" # This will be part of the path in the final URL, created if not found.
       containerName = ${?AZURE_CONTAINER_NAME}
+      cacheMaxAge = 5 seconds
+      cacheMaxAge = ${?CACHE_MAX_AGE}
     }
   }
 }

--- a/src/main/resources/environment.conf
+++ b/src/main/resources/environment.conf
@@ -21,8 +21,8 @@ bundler {
   dataType = "TripUpdate" # TripUpdate or ServiceAlert
   dataType = ${?DATA_TYPE}
   tripUpdate {
-    maxAge = 3 hours
-    maxAge = ${?TRIP_UPDATE_MAX_AGE}
+    contentMaxAge = 5 minutes
+    contentMaxAge = ${?TRIP_UPDATE_MAX_AGE}
   }
   output {
     fileName="HSL_TripUpdates_Full.pb"


### PR DESCRIPTION
Previously we just pruned the TripUpdate feedmessage (and it's entity & tripupdates) based on TU timestamp being too old (hours). Reason for long cache time is that we don't want to throw away stuff that might still have relevant data in the future. 

Google doesn't like this because it also contains past events for long time. This implementation peeks inside each tripupdate and searches the max timestamp for StopTimeUpdates it contains (Arrival & Departure). If all estimates are in the past for N minutes (config) that TripUpdate is filtered. This actually makes sense since it should never remove any tripupdates that have an estimate that concerns the future. 

should fix this: https://gitlab.hsl.fi/transitdata/gtfs-realtime-architecture/issues/188
could also fix this: https://gitlab.hsl.fi/transitdata/gtfs-realtime-architecture/issues/187